### PR TITLE
Fix missing import for `no_std` builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,11 @@ jobs:
         if: ${{ matrix.variant == 'minimal_versions' }}
         run: |
           cargo generate-lockfile -Z minimal-versions
+      - name: Build rand_distr
+        run: |
+          cargo build --target ${{ matrix.target }} --features=serde
+          cargo build --target ${{ matrix.target }} --no-default-features
+          cargo build --target ${{ matrix.target }} --no-default-features --features=std,std_math
       - name: Test rand_distr
         run: |
           cargo test --target ${{ matrix.target }} --features=serde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Testing
+- Added building the crate to CI
+
+### Fixes
+- Fix missing import for `no_std` builds
+
 ## [0.5.0] - 2025-01-27
 
 ### Dependencies and features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.1]
 
 ### Testing
 - Added building the crate to CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rand_distr"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/distr_test/Cargo.toml
+++ b/distr_test/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-rand_distr = { path = "..", version = "0.5.0", default-features = false, features = ["alloc"] }
+rand_distr = { path = "..", version = "0.5.1", default-features = false, features = ["alloc"] }
 rand = { version = "0.9.0", features = ["small_rng"] }
 num-traits = "0.2.19"
 # Special functions for testing distributions

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,8 @@
 //! Math helper functions
 
 use crate::ziggurat_tables;
+#[allow(unused_imports)]
+use num_traits::Float; // Used for `no_std` to get `f64::abs()` working before `rustc 1.84`
 use rand::distr::hidden_export::IntoFloat;
 use rand::Rng;
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This PR fixes a missing import for `no_std` builds for `rustc` version 1.83 and older. 

# Motivation

When I tried to update my crate to `rand` 0.9.0 and `rand_distr` 0.5.0, my CI failed. So I needed to do something about it. What can be better than fixing the issue upstream?

# Details

When `rand_distr` is build with `--no-default-features` using 
```bash
rustup run "1.63.0" cargo build --no-default-features
```
or any other `rustc` version up to 1.83, the build fails in `src/utils.rs` in the line 
```rustc
let test_x = if symmetric { x.abs() } else { x };
```
complaining that `f64` does not offer the method `abs()`. The added import 
```
use num_traits::Float;
```
fixes this issue. 

In addition, I updated `.github/workflows/test.yml`, so `cargo build` is executed for all existing test configurations. Previously, only `cargo test` was executed, but it looks like this is not sufficient to trigger the build failure. 

This fixes issue #12. 