### PR TITLE
Remove const-generic size parameter from Dirichlet distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - unreleased
+
+### API changes
+- `Dirichlet` no longer uses `const` generics, which means that its size is not required at compile time. Essentially a revert of #1292
+- Add `Dirichlet::new_with_size` constructor
+
 ## [0.5.1]
 
 ### Testing

--- a/tests/value_stability.rs
+++ b/tests/value_stability.rs
@@ -502,11 +502,11 @@ fn weibull_stability() {
 fn dirichlet_stability() {
     let mut rng = get_rng(223);
     assert_eq!(
-        rng.sample(Dirichlet::new([1.0, 2.0, 3.0]).unwrap()),
+        rng.sample(Dirichlet::new(&[1.0, 2.0, 3.0]).unwrap()),
         [0.12941567177708177, 0.4702121891675036, 0.4003721390554146]
     );
     assert_eq!(
-        rng.sample(Dirichlet::new([8.0; 5]).unwrap()),
+        rng.sample(Dirichlet::new(&[8.0; 5]).unwrap()),
         [
             0.17684200044809556,
             0.29915953935953055,
@@ -517,7 +517,7 @@ fn dirichlet_stability() {
     );
     // Test stability for the case where all alphas are less than 0.1.
     assert_eq!(
-        rng.sample(Dirichlet::new([0.05, 0.025, 0.075, 0.05]).unwrap()),
+        rng.sample(Dirichlet::new(&[0.05, 0.025, 0.075, 0.05]).unwrap()),
         [
             0.00027580456855692104,
             2.296135759821706e-20,


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
This PR is essentially a revert of https://github.com/rust-random/rand/pull/1292, which changed the Dirichlet distribution to be const-generic over size. This broke my use case, which requires a Dirichlet distribution where the vector size is not known at compile time, see below.


# Background
The original change was discussed in https://github.com/rust-random/rand/pull/1292, #8 and https://github.com/rust-random/rand/issues/496. I've also created #14 to discuss reverting that change.

The issue of *requiring* a statically known size doesn't seem to have been recognized at the time. It's only mentioned in[ a comment](https://github.com/rust-random/rand/issues/496#issuecomment-2122019820) by @dhardy after the code was merged:

> Caveat: the above approach does not support run-time variable length N. We likely don't need to care about this.

I don't think this is correct. A Dirichlet distribution over a dynamic number of elements was used in [AlphaZero](https://arxiv.org/abs/1712.01815), one of the most widely read machine learning papers in the field. See the paper and [this StackExchange post](https://stats.stackexchange.com/questions/322831/purpose-of-dirichlet-noise-in-the-alphazero-paper) for details. This is essentially my use case, and given the impact of the paper, I'm sure many other people are doing this.

Additionally, it's not clear to me why the Dirichlet implementation needs to be const-generic at all, apart from a general desire to reduce the number of memory allocations. The performance hit is negligible for any use case I can imagine (feel free to prove me wrong here), and const-generic Dirichlet still requires an allocation, meaning it can't be used without the `alloc` feature.

# Details

Even though the change was only released a month ago with `0.5`, it was merged almost two years ago, and the code has changed substantially in the meantime. I removed the const generics manually, making as few other changes as possible, so it's possible that the code can now be simplified by someone with a better understand of statistics.