### PR TITLE
Reconstruct weights in WeightedAliasIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2]
 
 ### API Changes
-- Add `WeightedAliasIndex::weights()` to enumerate weights in O(n) setup
+- Add `WeightedAliasIndex::weights()` to reconstruct the original weights in O(n)
 
 ### Testing
 - Added a test for `WeightedAliasIndex::weights()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480)
 - Remove support for usage of `isize` as a `WeightedAliasIndex` weight (#1487)
 - Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
+- Add `WeightedAlias::weights()` to enumerate weights in O(n)
 
 ### API changes: renames
 - Move `Slice` -> `slice::Choose`, `EmptySlice` -> `slice::Empty` (#1548)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,40 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2]
+
+### API Changes
+
+- Add `WeightedAliasIndex::weights()` to enumerate weights in O(n) setup
+
+### Testing
+
+- Added a test for `WeightedAliasIndex::weights()`
+
 ## [0.5.1]
 
 ### Testing
+
 - Added building the crate to CI
 
 ### Fixes
+
 - Fix missing import for `no_std` builds
 
 ## [0.5.0] - 2025-01-27
 
 ### Dependencies and features
+
 - Bump the MSRV to 1.61.0 (#1207, #1246, #1269, #1341, #1416); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
 - Update to `rand` v0.9.0 (#1558)
 - Rename feature `serde1` to `serde` (#1477)
 
 ### API changes
+
 - Make distributions comparable with `PartialEq` (#1218)
 - `Dirichlet` now uses `const` generics, which means that its size is required at compile time (#1292)
 - The `Dirichlet::new_with_size` constructor was removed (#1292)
@@ -29,9 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480)
 - Remove support for usage of `isize` as a `WeightedAliasIndex` weight (#1487)
 - Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
-- Add `WeightedAlias::weights()` to enumerate weights in O(n) setup
 
 ### API changes: renames
+
 - Move `Slice` -> `slice::Choose`, `EmptySlice` -> `slice::Empty` (#1548)
 - Rename trait `DistString` -> `SampleString` (#1548)
 - Rename `DistIter` -> `Iter`, `DistMap` -> `Map` (#1548)
@@ -40,9 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `weighted_tree::WeightedTreeIndex` -> `weighted::WeightedTreeIndex` (#1548)
 
 ### Testing
+
 - Add Kolmogorov Smirnov tests for distributions (#1494, #1504, #1525, #1530)
 
 ### Fixes
+
 - Fix Knuth's method so `Poisson` doesn't return -1.0 for small lambda (#1284)
 - Fix `Poisson` distribution instantiation so it return an error if lambda is infinite (#1291)
 - Fix Dirichlet sample for small alpha values to avoid NaN samples (#1209)
@@ -53,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `Hypergeometric`, this is a Value-breaking change (#1510)
 
 ### Other changes
+
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
   This breaks serialization compatibility with older versions.
 - Add plots for `rand_distr` distributions to documentation (#1434)
@@ -60,24 +78,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reimplement `Poisson`'s rejection method to improve performance and correct sampling inaccuracies for large lambda values, this is a Value-breaking change (#1560)
 
 ## [0.4.3] - 2021-12-30
+
 - Fix `no_std` build (#1208)
 
 ## [0.4.2] - 2021-09-18
+
 - New `Zeta` and `Zipf` distributions (#1136)
 - New `SkewNormal` distribution (#1149)
 - New `Gumbel` and `Frechet` distributions (#1168, #1171)
 
 ## [0.4.1] - 2021-06-15
+
 - Empirically test PDF of normal distribution (#1121)
 - Correctly document `no_std` support (#1100)
 - Add `std_math` feature to prefer `std` over `libm` for floating point math (#1100)
 - Add mean and std_dev accessors to Normal (#1114)
 - Make sure all distributions and their error types implement `Error`, `Display`, `Clone`,
- `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
+  `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
 - Port benchmarks to use Criterion crate (#1116)
 - Support serde for distributions (#1141)
 
 ## [0.4.0] - 2020-12-18
+
 - Bump `rand` to v0.8.0
 - New `Geometric`, `StandardGeometric` and `Hypergeometric` distributions (#1062)
 - New `Beta` sampling algorithm for improved performance and accuracy (#1000)
@@ -85,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variants of `NormalError` changed (#1044)
 
 ## [0.3.0] - 2020-08-25
+
 - Move alias method for `WeightedIndex` from `rand` (#945)
 - Rename `WeightedIndex` to `WeightedAliasIndex` (#1008)
 - Replace custom `Float` trait with `num-traits::Float` (#987)
@@ -100,14 +123,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add value stability tests for distributions (#891)
 
 ## [0.2.2] - 2019-09-10
+
 - Fix version requirement on rand lib (#847)
 - Clippy fixes & suppression (#840)
 
 ## [0.2.1] - 2019-06-29
+
 - Update dependency to support Rand 0.7
 - Doc link fixes
 
 ## [0.2.0] - 2019-06-06
+
 - Remove `new` constructors for zero-sized types
 - Add Pert distribution
 - Fix undefined behavior in `Poisson`
@@ -117,4 +143,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `UnitBall` and `UnitDisc`
 
 ## [0.1.0] - 2019-06-06
+
 Initial release. This is equivalent to the code in `rand` 0.6.5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `WeightError`, `PoissonError`, `BinomialError` as `#[non_exhaustive]` (#1480)
 - Remove support for usage of `isize` as a `WeightedAliasIndex` weight (#1487)
 - Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
-- Add `WeightedAlias::weights()` to enumerate weights in O(n)
+- Add `WeightedAlias::weights()` to enumerate weights in O(n) setup
 
 ### API changes: renames
 - Move `Slice` -> `slice::Choose`, `EmptySlice` -> `slice::Empty` (#1548)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -8,33 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2]
 
 ### API Changes
-
 - Add `WeightedAliasIndex::weights()` to enumerate weights in O(n) setup
 
 ### Testing
-
 - Added a test for `WeightedAliasIndex::weights()`
 
 ## [0.5.1]
 
 ### Testing
-
 - Added building the crate to CI
 
 ### Fixes
-
 - Fix missing import for `no_std` builds
 
 ## [0.5.0] - 2025-01-27
 
 ### Dependencies and features
-
 - Bump the MSRV to 1.61.0 (#1207, #1246, #1269, #1341, #1416); note that 1.60.0 may work for dependents when using `--ignore-rust-version`
 - Update to `rand` v0.9.0 (#1558)
 - Rename feature `serde1` to `serde` (#1477)
 
 ### API changes
-
 - Make distributions comparable with `PartialEq` (#1218)
 - `Dirichlet` now uses `const` generics, which means that its size is required at compile time (#1292)
 - The `Dirichlet::new_with_size` constructor was removed (#1292)
@@ -46,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change parameter type of `Zipf::new`: `n` is now floating-point (#1518)
 
 ### API changes: renames
-
 - Move `Slice` -> `slice::Choose`, `EmptySlice` -> `slice::Empty` (#1548)
 - Rename trait `DistString` -> `SampleString` (#1548)
 - Rename `DistIter` -> `Iter`, `DistMap` -> `Map` (#1548)
@@ -55,11 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move `weighted_tree::WeightedTreeIndex` -> `weighted::WeightedTreeIndex` (#1548)
 
 ### Testing
-
 - Add Kolmogorov Smirnov tests for distributions (#1494, #1504, #1525, #1530)
 
 ### Fixes
-
 - Fix Knuth's method so `Poisson` doesn't return -1.0 for small lambda (#1284)
 - Fix `Poisson` distribution instantiation so it return an error if lambda is infinite (#1291)
 - Fix Dirichlet sample for small alpha values to avoid NaN samples (#1209)
@@ -70,7 +60,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug in `Hypergeometric`, this is a Value-breaking change (#1510)
 
 ### Other changes
-
 - Remove unused fields from `Gamma`, `NormalInverseGaussian` and `Zipf` distributions (#1184)
   This breaks serialization compatibility with older versions.
 - Add plots for `rand_distr` distributions to documentation (#1434)
@@ -78,28 +67,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reimplement `Poisson`'s rejection method to improve performance and correct sampling inaccuracies for large lambda values, this is a Value-breaking change (#1560)
 
 ## [0.4.3] - 2021-12-30
-
 - Fix `no_std` build (#1208)
 
 ## [0.4.2] - 2021-09-18
-
 - New `Zeta` and `Zipf` distributions (#1136)
 - New `SkewNormal` distribution (#1149)
 - New `Gumbel` and `Frechet` distributions (#1168, #1171)
 
 ## [0.4.1] - 2021-06-15
-
 - Empirically test PDF of normal distribution (#1121)
 - Correctly document `no_std` support (#1100)
 - Add `std_math` feature to prefer `std` over `libm` for floating point math (#1100)
 - Add mean and std_dev accessors to Normal (#1114)
 - Make sure all distributions and their error types implement `Error`, `Display`, `Clone`,
-  `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
+ `Copy`, `PartialEq` and `Eq` as appropriate (#1126)
 - Port benchmarks to use Criterion crate (#1116)
 - Support serde for distributions (#1141)
 
 ## [0.4.0] - 2020-12-18
-
 - Bump `rand` to v0.8.0
 - New `Geometric`, `StandardGeometric` and `Hypergeometric` distributions (#1062)
 - New `Beta` sampling algorithm for improved performance and accuracy (#1000)
@@ -107,7 +92,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Variants of `NormalError` changed (#1044)
 
 ## [0.3.0] - 2020-08-25
-
 - Move alias method for `WeightedIndex` from `rand` (#945)
 - Rename `WeightedIndex` to `WeightedAliasIndex` (#1008)
 - Replace custom `Float` trait with `num-traits::Float` (#987)
@@ -123,17 +107,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add value stability tests for distributions (#891)
 
 ## [0.2.2] - 2019-09-10
-
 - Fix version requirement on rand lib (#847)
 - Clippy fixes & suppression (#840)
 
 ## [0.2.1] - 2019-06-29
-
 - Update dependency to support Rand 0.7
 - Doc link fixes
 
 ## [0.2.0] - 2019-06-06
-
 - Remove `new` constructors for zero-sized types
 - Add Pert distribution
 - Fix undefined behavior in `Poisson`
@@ -143,5 +124,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `UnitBall` and `UnitDisc`
 
 ## [0.1.0] - 2019-06-06
-
 Initial release. This is equivalent to the code in `rand` 0.6.5.

--- a/benches/benches/weighted.rs
+++ b/benches/benches/weighted.rs
@@ -49,7 +49,7 @@ pub fn bench(c: &mut Criterion) {
         (1000, 1_000_000, "1M"),
     ];
     for (amount, length, len_name) in lens {
-        let name = format!("weighted_sample_indices_{}_of_{}", amount, len_name);
+        let name = format!("weighted_sample_indices_{amount}_of_{len_name}");
         c.bench_function(name.as_str(), |b| {
             let length = black_box(length);
             let amount = black_box(amount);

--- a/src/weighted/weighted_alias.rs
+++ b/src/weighted/weighted_alias.rs
@@ -261,13 +261,13 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
 
         // Reconstruct each weight by combining its direct `no_alias_odds`
         // with its total `alias_contributions` and scaling the result.
-        let mut reconstructed_weights = Vec::with_capacity(n);
-        for k in 0..n {
-            let total_odds = self.no_alias_odds[k] + alias_contributions[k];
-            reconstructed_weights.push(total_odds / n_converted);
-        }
-
-        reconstructed_weights
+        self.no_alias_odds
+            .iter()
+            .zip(&alias_contributions)
+            .map(|(&no_alias_odd, &alias_contribution)| {
+                (no_alias_odd + alias_contribution) / n_converted
+            })
+            .collect()
     }
 }
 
@@ -307,7 +307,7 @@ where
             no_alias_odds: self.no_alias_odds.clone(),
             uniform_index: self.uniform_index,
             uniform_within_weight_sum: self.uniform_within_weight_sum.clone(),
-            weight_sum: self.weight_sum.clone(),
+            weight_sum: self.weight_sum,
         }
     }
 }

--- a/src/weighted/weighted_alias.rs
+++ b/src/weighted/weighted_alias.rs
@@ -247,14 +247,13 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
 
         // `n` was validated in the constructor.
         let n_converted = W::try_from_u32_lossy(n as u32).unwrap();
-        let weight_sum = self.weight_sum;
 
         // pre-calculate the total contribution each index receives from serving
         // as an alias for other indices.
         let mut alias_contributions = vec![W::ZERO; n];
         for j in 0..n {
-            if self.no_alias_odds[j] < weight_sum {
-                let contribution = weight_sum - self.no_alias_odds[j];
+            if self.no_alias_odds[j] < self.weight_sum {
+                let contribution = self.weight_sum - self.no_alias_odds[j];
                 let alias_index = self.aliases[j] as usize;
                 alias_contributions[alias_index] += contribution;
             }

--- a/src/weighted/weighted_alias.rs
+++ b/src/weighted/weighted_alias.rs
@@ -238,12 +238,11 @@ impl<W: AliasableWeight> WeightedAliasIndex<W> {
 
     /// Reconstructs and returns the original weights used to create the distribution.
     ///
-    /// This method has `O(n)` time complexity, where `n` is the number of weights.
+    /// `O(n)` time, where `n` is the number of weights.
+    ///
+    /// Note: Exact values may not be recovered if `W` is a float.
     pub fn weights(&self) -> Vec<W> {
         let n = self.aliases.len();
-        if n == 0 {
-            return Vec::new();
-        }
 
         // `n` was validated in the constructor.
         let n_converted = W::try_from_u32_lossy(n as u32).unwrap();


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary
Added `WeightedAliasIndex::weights` which allows enumeration of the weights inputted into the constructor in O(n) creation .

# Motivation
`WeightedIndex` and `WeightedIndexTree` both reveal a public api to enumerate the distributions weights. `WeightedAliasIndex::new` takes ownership of the vector passed in, and a codebase may not want to keep a cloned vector of input weights.

It is a critical debugging feature to be able to enumerate the weights `WeightedAliasIndex` is constructed with.

# Details
`weights()` inverts the work done to create `alias_contributions` and `no_alias_odds`. This algorithm relies on `weight_sum` being cached.