### PR TITLE
CI-Fix

### DIFF
--- a/distr_test/Cargo.toml
+++ b/distr_test/Cargo.toml
@@ -10,6 +10,6 @@ rand = { version = "0.9.0", features = ["small_rng"] }
 num-traits = "0.2.19"
 # Special functions for testing distributions
 special = "0.11.0"
-spfunc = "0.1.0"
+spfunc = "=0.1.0"
 # Cdf implementation
 statrs = "0.17.1"


### PR DESCRIPTION
I pin `spfunc`, because the new version has non working (needs additional setup) dependencies (`plotters`). It is only used in the `distr_test` part.
