### PR TITLE
remove doc_auto_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 )]
 #![allow(clippy::neg_cmp_op_on_partial_ord)] // suggested fix too verbose
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Generating random samples from probability distributions.
 //!


### PR DESCRIPTION
# Motivation

https://github.com/rust-lang/rust/pull/138907

# Details

I am not completely sure if we can just drop it now, but it seems like we can.