### PR TITLE
Remove minimal-versions testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,10 +74,6 @@ jobs:
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu
             toolchain: nightly
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            toolchain: nightly
-            variant: minimal_versions
 
     steps:
       - uses: actions/checkout@v4
@@ -90,10 +86,6 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.toolchain }}
       - run: ${{ matrix.deps }}
-      - name: Maybe minimal versions
-        if: ${{ matrix.variant == 'minimal_versions' }}
-        run: |
-          cargo generate-lockfile -Z minimal-versions
       - name: Build rand_distr
         run: |
           cargo build --target ${{ matrix.target }} --features=serde


### PR DESCRIPTION
- [ ] Added a `CHANGELOG.md` entry

# Summary

Remove testing with minimal-versions

# Details

I don't think we have any choice here:

- `minimal-versions` is an unstable feature hence only usable on nightly rustc
- We depend (transitively) on `proc-macro2` which uses a `build.rs` to opt into unstable features
- ~~The latest version of `serde` still resolves an old version of `proc-macro2` (1.0.55) which is incompatible with recent nightly rustc~~

I'm not going to add a direct dependency on `proc-macro2` just to force a more recent version. I suppose we *could* add a hack to `test.yml` to update to a more recent version of `proc-macro2`, but I do not want to maintain a messy hack which forces CI tweaks just because some unstable interface changes.

(Arguably `proc-macro2` is broken by design auto-enabling nightly features. `proc-macro-error2` specifically avoids auto-enabling unstable features for this reason. But this is not my problem to solve.)