### PR TITLE
Avoid panic with almost-zero parameters for FisherF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Fix `Geometric::new` for small `p > 0` where `1 - p` rounds to 1 (#36)
+- Fix panic in `FisherF::new` on almost zero parameters (#39)
 
 ## [0.5.2]
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

When `m` or `n` is a positive floating point value with `0.5 m = 0.0` (e.g. 1e-45 for f32, or 5e-324 for f64) the constructor of FisherF could panic in one of the  unwrap() calls.

# Motivation

This is one of the unusual-parameter panics that I found by fuzzing, and fixing it turned out to be simple. (There's only a few more simple panics from fuzzing, and I expect fixing them before tackling the much trickier Binomial and Hypergeometric samplers may make things easier. And I'm not in a hurry :-). )

# Details

The workaround is to reject FisherF distributions with `m` or `n` almost zero instead of unwrapping. I expect that in practice people only use integral `m` and `n`.