### PR TITLE
Avoid panic on large alpha for NormalInverseGaussian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Fix `Geometric::new` for small `p > 0` where `1 - p` rounds to 1 (#36)
 - Fix panic in `FisherF::new` on almost zero parameters (#39)
+- Fix panic in `NormalInverseGaussian::new` with very large `alpha`; this is a Value-breaking change (#40)
 
 ## [0.5.2]
 

--- a/src/normal_inverse_gaussian.rs
+++ b/src/normal_inverse_gaussian.rs
@@ -1,4 +1,4 @@
-use crate::{Distribution, InverseGaussian, StandardNormal, StandardUniform};
+use crate::{Distribution, InverseGaussian, InverseGaussianError, StandardNormal, StandardUniform};
 use core::fmt;
 use num_traits::Float;
 use rand::Rng;
@@ -8,6 +8,8 @@ use rand::Rng;
 pub enum Error {
     /// `alpha <= 0` or `nan`.
     AlphaNegativeOrNull,
+    /// `alpha` is `inf` (or, if subnormals are disabled, too close to the maximum finite float value)
+    AlphaInfinite,
     /// `|beta| >= alpha` or `nan`.
     AbsoluteBetaNotLessThanAlpha,
 }
@@ -17,6 +19,9 @@ impl fmt::Display for Error {
         f.write_str(match self {
             Error::AlphaNegativeOrNull => {
                 "alpha <= 0 or is NaN in normal inverse Gaussian distribution"
+            }
+            Error::AlphaInfinite => {
+                "alpha is +infinity (or too close to the maximum finite value, if subnormal numbers are not supported) in normal inverse Gaussian distribution"
             }
             Error::AbsoluteBetaNotLessThanAlpha => {
                 "|beta| >= alpha or is NaN in normal inverse Gaussian distribution"
@@ -68,6 +73,9 @@ where
 {
     /// Construct a new `NormalInverseGaussian` distribution with the given alpha (tail heaviness) and
     /// beta (asymmetry) parameters.
+    ///
+    /// Note: If subnormal numbers are not supported or are disabled, this sampler may panic or produce
+    /// incorrect output if alpha is close to the maximum finite float value.
     pub fn new(alpha: F, beta: F) -> Result<NormalInverseGaussian<F>, Error> {
         if !(alpha > F::zero()) {
             return Err(Error::AlphaNegativeOrNull);
@@ -76,12 +84,16 @@ where
         if !(beta.abs() < alpha) {
             return Err(Error::AbsoluteBetaNotLessThanAlpha);
         }
-
-        let gamma = (alpha * alpha - beta * beta).sqrt();
-
+        // Note: this calculation method for gamma = sqrt(alpha * alpha - beta * beta)
+        // avoids overflow if alpha is large, ensuring gamma <= alpha, which implies
+        // (assuming IEEE754 with subnormals) mu = 1.0 / gamma >= 1 / F::max_value() > 0.
+        let r = beta / alpha;
+        let gamma = alpha * (F::one() - r * r).sqrt();
         let mu = F::one() / gamma;
-
-        let inverse_gaussian = InverseGaussian::new(mu, F::one()).unwrap();
+        let inverse_gaussian = InverseGaussian::new(mu, F::one()).map_err(|x| match x {
+            InverseGaussianError::MeanNegativeOrNull => Error::AlphaInfinite,
+            InverseGaussianError::ShapeNegativeOrNull => unreachable!(),
+        })?;
 
         Ok(Self {
             beta,
@@ -124,6 +136,7 @@ mod tests {
         assert!(NormalInverseGaussian::new(-1.0, 1.0).is_err());
         assert!(NormalInverseGaussian::new(-1.0, -1.0).is_err());
         assert!(NormalInverseGaussian::new(1.0, 2.0).is_err());
+        assert!(NormalInverseGaussian::new(f64::INFINITY, 2.0).is_err());
         assert!(NormalInverseGaussian::new(2.0, 1.0).is_ok());
     }
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This changes the calculation in NormalInverseGaussian::new(), to avoid calculating `alpha * alpha`, which could produce `inf`, leading to an invalid (zero `mu`) parameter for InverseGaussian that triggers a panic.

The new parameter calculation can slightly affect the values sampled by the distribution.

# Motivation

This is another edge case found by fuzzing parameters, which is a bit more complicated to cleanly resolve.

# Details

Calculating `sqrt(alpha^2 - beta^2)` as `alpha sqrt(1 - (beta/alpha)^2)` may on normal inputs change the calculated value by, I think, up to 1 ulp at most.

Marking as draft, because I'm uncertain about how best to resolve the problem for `rand_distr`:

1. I don't know if handling alpha > 10^20 (for f32) cleanly is necessary, but doing so only required a small change. I can drop the gamma calculation changes and just error if `mu` is too small, if you'd prefer to preserve the existing calculation method.

2. This introduces an extra division on the normal path, and may very slightly change output values. These could be avoided in practice with a branch to use the different calculation if `alpha^2` overflows. Would you prefer to have this sort of backwards compatibility/stability?

3. Is `rand_distr` expected to be run under a particular [rounding mode](https://en.wikipedia.org/wiki/IEEE_754#Rounding_rules)? (The specific calculation used here should still work (be relatively accurate and produce `mu > 0.0`) in any rounding mode.)

4. Is `rand_distr` expected to be run with full IEEE754 floats (including subnormal numbers)?  I couldn't find documentation of this for the `num_traits::Float` trait. The updated calculation needs these to avoid producing `mu = 0.0` when `alpha` is e.g. the largest finite f32 value. I could also just introduce a new error if `mu = 0.0`.
