### PR TITLE
Avoid hangs and debug asserts on invalid parameters for Zipf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `direct-minimal-versions` (#38)
 - Fix panic in `FisherF::new` on almost zero parameters (#39)
 - Fix panic in `NormalInverseGaussian::new` with very large `alpha`; this is a Value-breaking change (#40)
+- Fix hang and debug assertion in `Zipf::new` on invalid parameters (#41)
 - Fix panic in `Binomial::sample` with `n ≥ 2^63`; this is a Value-breaking change (#43)
 - Error instead of producing `-inf` output for `Exp` when `lambda` is `-0.0` (#44)
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

The Zipf distribution sampler could panic (at `debug_assert!(t > F::zero());`) when given invalid parameters (like `s = inf`); or hang in an infinite loop when sampling. This change rejects parameter combinations for which the generalized Zipf distribution is not well defined, and slightly modifies Zipf::new() so that sampling avoids the debug assert and produces the correct value when `s = inf`.

# Motivation

This another simple panic / hang issue that I found by fuzzing input parameters.

# Details

The normalization constant (sum from i=1 to n of 1/i^s) of the [generalized Zipf distribution](https://en.wikipedia.org/wiki/Zipf's_law#Formal_definition) needs to be positive and finite for the distribution to be well defined.  if `s <= 1` and `n = inf`, then the sum in the constant diverges.

If `s = inf`, then each term of the constant is 0, so the specific formula in Wikipedia will not work; however, the Zipf distribution approaches the distribution concentrated on `i=1` as `s -> inf`. The previous implementation computed a `nan` in Zipf::new which triggered the debug assertion (or an infinite loop), but a small change avoids both.

(Edit: originally this PR rejected the case `s = inf`, but after posting it I changed my mind; in general, if a limiting distribution exists and is close enough to the distribution at the largest finite parameters, then producing that limiting distribution is safe and avoids having the library user write a special case to produce effectively that limiting distribution.)
