### PR TITLE
Avoid panics in Binomial BTPE sampler by using u64 values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `direct-minimal-versions` (#38)
 - Fix panic in `FisherF::new` on almost zero parameters (#39)
 - Fix panic in `NormalInverseGaussian::new` with very large `alpha`; this is a Value-breaking change (#40)
+- Fix panic in `Binomial::sample` with `n ≥ 2^63`; this is a Value-breaking change (#43)
 - Error instead of producing `-inf` output for `Exp` when `lambda` is `-0.0` (#44)
 
 ## [0.5.2]


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This fixes a panic that can occur when the parameter `n` for the `Binomial` sampler is larger than `i64::MAX`.

# Motivation

This should resolve https://github.com/rust-random/rand_distr/issues/21 .

# Details

The key variable which previously used `i64` in `binomial::btpe` was `y`, the random coordinate in 0..=n on which the BTPE algorithm performed rejection sampling. Since `n` is in `0..u64::MAX`, `y` should also be in `u64::MAX`.

This is a value-breaking change, because e.g. the code now does the float->int cast on the value `x_l + v.ln() / lambda_l` after checking whether the value is <= 0, instead of before. I don't think this sort of change in boundary rounding should cause any issues (and it may make the sampled distribution closer to the actual target.) ~I am looking into writing a test to confirm this is OK, but it may be a few weeks before it is ready.~ (Tested, the new version actually fixes a boundary issue, see test for it in #47.)