### PR TITLE
Forbid negative zero lambda in Exp distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `direct-minimal-versions` (#38)
 - Fix panic in `FisherF::new` on almost zero parameters (#39)
 - Fix panic in `NormalInverseGaussian::new` with very large `alpha`; this is a Value-breaking change (#40)
+- Error instead of producing `-inf` output for `Exp` when `lambda` is `-0.0` (#44)
 
 ## [0.5.2]
 


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

Passing `lambda = -0.0` to `Exp::new()` produced an unexpected output, `-inf` for the distribution; this PR forbids the value and returns an error.

# Motivation

I noticed this edge case with a parameter fuzzer (https://github.com/mstoeckl/rand_distr/commits/fuzz-params/).

# Details

The sampler produced unexpected output (`-inf`) when `lambda = -0.0` was provided, because `lambda_inverse` evaluated to `1.0 / -0.0 = -inf`. If `-0.0` does appear as an argument, it is likely the result of an incorrect calculation. In contrast, `0.0` more likely occurs as a limit or rounded output of some process or formula that typically produces positive values.

A related discussion from around the time the Exp(0) feature was introduced is https://github.com/statrs-dev/statrs/issues/102 .

Alternatively, one could make `-0.0` behave the same as +0.0 and make `Exp` return +inf. 