### PR TITLE
Change Poisson algorithm threshold to >=10 per Ahrens-Dieter paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Testing
 - Added a parameter fuzzing script to search for panics and invalid output ([#53])
 
+### Changes
+- Changed threshold for Ahrens-Dieter PD algorithm to >=10, matching the suggested value in the original 1982 paper
+
 ## [0.6.0] — 2026-02-10
 - Bump to MSRV 1.85.0 and Edition 2024 in line with `rand` ([#28])
 - Update `rand` to version 0.10.0 ([#31], [#48])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 - Avoid returning negative values in `InverseGaussian::sample`; this is a Value-breaking change ([#56])
 - Fix Zipf returning values larger than `n` in rare cases ([#57])
+- Changed threshold for Ahrens-Dieter PD algorithm to >=10, matching the suggested value in the original 1982 paper
 
 ## [0.6.0] — 2026-02-10
 - Bump to MSRV 1.85.0 and Edition 2024 in line with `rand` ([#28])

--- a/src/poisson.rs
+++ b/src/poisson.rs
@@ -161,7 +161,9 @@ where
         }
 
         // Use the Knuth method only for low expected values
-        let method = if lambda < F::from(12.0).unwrap() {
+        // Per Ahrens-Dieter, the rejection sampling algorithm is
+        // only designed for values >= 10
+        let method = if lambda < F::from(10.0).unwrap() {
             Method::Knuth(KnuthMethod::new(lambda))
         } else {
             if lambda > F::from(Self::MAX_LAMBDA).unwrap() {


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

I am not sure why `12.0` was originally chosen, but the threshold recommended by the [original 1982 paper](https://dl.acm.org/doi/abs/10.1145/355993.355997) is `mu>=10` so this would be an improvement for values 10–12. The algorithm would be faster for even lower values, but there are features (such as the hat function, defined in equation 24) that are specifically designed only to work down to `mu = 10`; the authors suggest this is the case and if you take a look at my comment here https://github.com/JuliaStats/Distributions.jl/pull/2060, you can see that using lower values does indeed introduce bias. 

