### PR TITLE
Change InverseGaussian calculation to always produce nonnegative values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a parameter fuzzing script to search for panics and invalid output ([#53])
 
 ### Fixes
+- Avoid returning negative values in `InverseGaussian::sample`; this is a Value-breaking change ([#56])
 - Fix Zipf returning values larger than `n` in rare cases ([#57])
 
 ## [0.6.0] — 2026-02-10
@@ -165,6 +166,7 @@ Initial release. This is equivalent to the code in `rand` 0.6.5.
 [#46]: https://github.com/rust-random/rand_distr/pull/46
 [#48]: https://github.com/rust-random/rand_distr/pull/48
 [#53]: https://github.com/rust-random/rand_distr/pull/53
+[#56]: https://github.com/rust-random/rand_distr/pull/56
 [#57]: https://github.com/rust-random/rand_distr/pull/57
 [rand#840]: https://github.com/rust-random/rand/pull/840
 [rand#847]: https://github.com/rust-random/rand/pull/847

--- a/benches/benches/distr.rs
+++ b/benches/benches/distr.rs
@@ -106,6 +106,10 @@ fn bench(c: &mut Criterion<CyclesPerByte>) {
     distr_float!(g, "cauchy", f64, Cauchy::new(4.2, 6.9).unwrap());
     g.finish();
 
+    let mut g = c.benchmark_group("inverse_gaussian");
+    distr_float!(g, "inverse_gaussian", f64, InverseGaussian::new(1.1, 0.9).unwrap());
+    g.finish();
+
     let mut g = c.benchmark_group("triangular");
     distr_float!(g, "triangular", f64, Triangular::new(0., 1., 0.9).unwrap());
     g.finish();

--- a/distr_test/tests/cdf.rs
+++ b/distr_test/tests/cdf.rs
@@ -306,6 +306,42 @@ fn beta() {
 }
 
 #[test]
+fn inverse_gaussian() {
+    use rand_distr::InverseGaussian;
+    fn norm_cdf(x: f64, mu: f64, sigma: f64) -> f64 {
+        use special::Primitive;
+        0.5 * (1.0 + Primitive::erf((x - mu) / (sigma * 2.0.sqrt())))
+    }
+    fn std_cdf(x: f64) -> f64 {
+        norm_cdf(x, 0.0, 1.0)
+    }
+
+    fn cdf(x: f64, mean: f64, shape: f64) -> f64 {
+        if x < 0.0 {
+            return 0.0;
+        }
+        std_cdf((shape / x).sqrt() * (x / mean - 1.0))
+            + (2.0 * shape / mean).exp() * std_cdf(-(shape / x).sqrt() * (x / mean + 1.0))
+    }
+
+    // mu, lambda
+    let parameters = [
+        (1.0, 1e-3),
+        (0.5, 1.0),
+        (1.0, 0.5),
+        (1.0, 1.0),
+        (1.0, 2.0),
+        (2.0, 1.0),
+        (1.0, 1e3),
+    ];
+
+    for (seed, (mean, shape)) in parameters.into_iter().enumerate() {
+        let dist = InverseGaussian::new(mean, shape).unwrap();
+        test_continuous(seed as u64, dist, |x| cdf(x, mean, shape));
+    }
+}
+
+#[test]
 fn triangular() {
     fn cdf(x: f64, a: f64, b: f64, c: f64) -> f64 {
         if x <= a {

--- a/src/inverse_gaussian.rs
+++ b/src/inverse_gaussian.rs
@@ -56,7 +56,7 @@ where
     StandardUniform: Distribution<F>,
 {
     mean: F,
-    shape: F,
+    unscaled_sqrt_shape: F,
 }
 
 impl<F> InverseGaussian<F>
@@ -77,7 +77,11 @@ where
             return Err(Error::ShapeNegativeOrNull);
         }
 
-        Ok(Self { mean, shape })
+        let unscaled_sqrt_shape = (mean / shape).sqrt();
+        Ok(Self {
+            mean,
+            unscaled_sqrt_shape,
+        })
     }
 }
 
@@ -93,21 +97,20 @@ where
         R: Rng + ?Sized,
     {
         let mu = self.mean;
-        let l = self.shape;
 
         let v: F = rng.sample(StandardNormal);
-        let y = mu * v * v;
 
-        let mu_2l = mu / (F::from(2.).unwrap() * l);
-
-        let x = mu + mu_2l * (y - (F::from(4.).unwrap() * l * y + y * y).sqrt());
+        // This formula is algebraically equivalent to the sampling algorithm
+        // on Wikipedia, and avoids subtracting similar-sized quantities
+        let w = (F::from(0.5).unwrap() * v.abs()) * self.unscaled_sqrt_shape;
+        let z = (w + (w * w + F::one()).sqrt()).powi(2);
+        let x = mu / z;
 
         let u: F = rng.random();
 
         if u <= mu / (mu + x) {
             return x;
         }
-
         mu * mu / x
     }
 }

--- a/src/inverse_gaussian.rs
+++ b/src/inverse_gaussian.rs
@@ -104,14 +104,13 @@ where
         // on Wikipedia, and avoids subtracting similar-sized quantities
         let w = (F::from(0.5).unwrap() * v.abs()) * self.unscaled_sqrt_shape;
         let z = (w + (w * w + F::one()).sqrt()).powi(2);
-        let x = mu / z;
 
         let u: F = rng.random();
 
-        if u <= mu / (mu + x) {
-            return x;
+        if (z + F::one()) * u <= z {
+            return mu / z;
         }
-        mu * mu / x
+        mu * z
     }
 }
 

--- a/src/inverse_gaussian.rs
+++ b/src/inverse_gaussian.rs
@@ -77,7 +77,7 @@ where
             return Err(Error::ShapeNegativeOrNull);
         }
 
-        let unscaled_sqrt_shape = (mean / shape).sqrt();
+        let unscaled_sqrt_shape = (mean / shape).sqrt().min(F::infinity());
         Ok(Self {
             mean,
             unscaled_sqrt_shape,
@@ -103,12 +103,15 @@ where
         // This formula is algebraically equivalent to the sampling algorithm
         // on Wikipedia, and avoids subtracting similar-sized quantities
         let w = (F::from(0.5).unwrap() * v.abs()) * self.unscaled_sqrt_shape;
+        // Avoid NaN when v=0 and unscaled_sqrt_shape=inf
+        let w = w.min(F::infinity());
         let z = (w + (w * w + F::one()).sqrt()).powi(2);
 
         let u: F = rng.random();
 
         if (z + F::one()) * u <= z {
-            return mu / z;
+            // mu/z can be NaN only if mu=inf, in which case output inf
+            return (mu / z).min(F::infinity());
         }
         mu * z
     }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This updates the InverseGaussian sampler so that it no longer produces NaN or negative values in edge cases.

# Motivation

This makes the InverseGaussian sampler behavior better match the definition of the distribution. Out of range values can be unexpected for users of the library and lead to rare bugs.

# Details

There are three parts to this change:
* Rewrite the calculation to avoid adding and subtracting floating point quantities of similar magnitude; due to floating point error this could end up making the original variable `x` be negative. The algebra here uses a well known method to eliminate terms like sqrt(a) - sqrt(b):
<img width="385" height="646.5" alt="basic_algebra" src="https://github.com/user-attachments/assets/d7e2ae99-f744-4c26-b6d8-2e5132cf1a1a" />

* Optimize the output logic, because the previous change had sampling ~10% slower.
* Avoiding NaN output, by replacing NaNs with the most reasonable value at the points in which they are produced in the calculation (which happens to be `inf` for the calculations here) 