### PR TITLE
Ensure Zipf always returns values in range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Testing
 - Added a parameter fuzzing script to search for panics and invalid output ([#53])
 
+### Fixes
+- Fix Zipf returning values larger than `n` in rare cases ([#57])
+
 ## [0.6.0] — 2026-02-10
 - Bump to MSRV 1.85.0 and Edition 2024 in line with `rand` ([#28])
 - Update `rand` to version 0.10.0 ([#31], [#48])
@@ -162,6 +165,7 @@ Initial release. This is equivalent to the code in `rand` 0.6.5.
 [#46]: https://github.com/rust-random/rand_distr/pull/46
 [#48]: https://github.com/rust-random/rand_distr/pull/48
 [#53]: https://github.com/rust-random/rand_distr/pull/53
+[#57]: https://github.com/rust-random/rand_distr/pull/57
 [rand#840]: https://github.com/rust-random/rand/pull/840
 [rand#847]: https://github.com/rust-random/rand/pull/847
 [rand#891]: https://github.com/rust-random/rand/pull/891

--- a/fuzz/fuzz_targets/parameter.rs
+++ b/fuzz/fuzz_targets/parameter.rs
@@ -445,7 +445,8 @@ fn sample_one(rng: &mut TestRng, params: &Parameters) -> Option<()> {
         }
         P::Zipf { n, s } => {
             let v = black_box(Zipf::new(n, s).ok()?.sample(rng));
-            assert!(v >= 0.0 && (v.is_infinite() || v.fract() == 0.0), "{}", v);
+            assert!((v.is_infinite() || v.fract() == 0.0), "{}", v);
+            assert!(v >= 0.0 && v <= n.floor(), "{}", v);
         }
     }
     Some(())

--- a/src/zipf.rs
+++ b/src/zipf.rs
@@ -61,6 +61,7 @@ where
     s: F,
     t: F,
     q: F,
+    n_floor: F,
 }
 
 /// Error type returned from [`Zipf::new`].
@@ -124,7 +125,12 @@ where
             F::one() + n.ln()
         };
         debug_assert!(t > F::zero());
-        Ok(Zipf { s, t, q })
+        Ok(Zipf {
+            s,
+            t,
+            q,
+            n_floor: n.floor(),
+        })
     }
 
     /// Inverse cumulative density function
@@ -152,7 +158,7 @@ where
         let one = F::one();
         loop {
             let inv_b = self.inv_cdf(rng.sample(StandardUniform));
-            let x = (inv_b + one).floor();
+            let x = (inv_b + one).floor().min(self.n_floor);
             let mut ratio = x.powf(-self.s);
             if x > one {
                 ratio = ratio * inv_b.powf(self.s)
@@ -203,7 +209,7 @@ mod tests {
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
-            assert!(r >= 1.);
+            assert!(r >= 1. && r <= 10.0);
         }
     }
 
@@ -213,7 +219,7 @@ mod tests {
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
-            assert!(r >= 1.);
+            assert!(r >= 1. && r <= 10.0);
         }
     }
 
@@ -223,7 +229,7 @@ mod tests {
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
-            assert!(r >= 1.);
+            assert!(r >= 1. && r <= 10.0);
         }
         // TODO: verify that this is a uniform distribution
     }
@@ -244,7 +250,7 @@ mod tests {
         let mut rng = crate::test::rng(2);
         for _ in 0..1000 {
             let r = d.sample(&mut rng);
-            assert!(r >= 1.);
+            assert!(r >= 1. && r <= f64::MAX);
         }
         // TODO: verify that this is a zeta distribution
     }


### PR DESCRIPTION
- [x] Added a `CHANGELOG.md` entry

# Summary

This updates the Zipf sampler to always produce values in the range [1,n].

# Motivation

This should fix https://github.com/rust-random/rand_distr/issues/54.

# Details

Due to floating point error, it was possible for `x` to exceed `n` even with small values of `n`. Updating the calculations producing `x` to avoid that error entirely would probably require somewhat complicated biasing and rounding tricks, so it is easier to just clip the output at the end. I've explicitly updated `x` to be  `<= n.floor()` instead of just `<= n` to ensure the output remains integral even if `n` is not; this is compatible with the documentation of the Zipf sampler and matches non-erroneous current behavior. Because the overflow only occurs rarely (when the random sample is close to 1) this should have negligible effect on the distribution.
